### PR TITLE
Switched PBRemoteProgressSheet to PBTask

### DIFF
--- a/Classes/Controllers/PBHistorySearchController.h
+++ b/Classes/Controllers/PBHistorySearchController.h
@@ -10,12 +10,13 @@
 #import "PBHistorySearchMode.h"
 
 @class PBGitHistoryController;
+@class PBTask;
 
 @interface PBHistorySearchController : NSObject {
 	PBHistorySearchMode searchMode;
 	NSIndexSet *results;
 	NSTimer *searchTimer;
-	NSTask *backgroundSearchTask;
+	PBTask *backgroundSearchTask;
 	NSPanel *rewindPanel;
 }
 

--- a/Classes/Controllers/PBHistorySearchController.m
+++ b/Classes/Controllers/PBHistorySearchController.m
@@ -11,10 +11,9 @@
 #import "PBHistorySearchController.h"
 #import "PBGitHistoryController.h"
 #import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
 #import "PBGitDefaults.h"
 #import "PBCommitList.h"
-#import "PBEasyPipe.h"
-#import "PBGitBinary.h"
 #import "PBGitCommit.h"
 
 @interface PBHistorySearchController ()
@@ -394,8 +393,6 @@
 - (void)startBackgroundSearch
 {
 	if (backgroundSearchTask) {
-		NSFileHandle *handle = [[backgroundSearchTask standardOutput] fileHandleForReading];
-		[[NSNotificationCenter defaultCenter] removeObserver:self name:NSFileHandleReadToEndOfFileCompletionNotification object:handle];
 		[backgroundSearchTask terminate];
 	}
 
@@ -422,22 +419,21 @@
 			return;
 	}
 
-	backgroundSearchTask = [PBEasyPipe taskForCommand:[PBGitBinary path] withArgs:searchArguments inDir:[[historyController.repository workingDirectoryURL] path]];
-	[backgroundSearchTask launch];
-
-	NSFileHandle *handle = [[backgroundSearchTask standardOutput] fileHandleForReading];
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(parseBackgroundSearchResults:) name:NSFileHandleReadToEndOfFileCompletionNotification object:handle];
-	[handle readToEndOfFileInBackgroundAndNotify];
+	backgroundSearchTask = [historyController.repository taskWithArguments:searchArguments];
+	[backgroundSearchTask performTaskWithCompletionHandler:^(NSData * _Nullable readData, NSError * _Nullable error) {
+		if (!readData) {
+			[historyController.windowController showErrorSheet:error];
+			return;
+		}
+		[self parseBackgroundSearchResults:readData];
+	}];
 
 	[self startProgressIndicator];
 }
 
-- (void)parseBackgroundSearchResults:(NSNotification *)notification
+- (void)parseBackgroundSearchResults:(NSData *)data
 {
-	[[NSNotificationCenter defaultCenter] removeObserver:self name:NSFileHandleReadToEndOfFileCompletionNotification object:[notification object]];
 	backgroundSearchTask = nil;
-
-	NSData *data = [[notification userInfo] valueForKey:NSFileHandleNotificationDataItem];
 
 	NSString *resultsString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 	NSArray *resultsArray = [resultsString componentsSeparatedByString:@"\n"];

--- a/Classes/Controllers/PBRepositoryDocumentController.m
+++ b/Classes/Controllers/PBRepositoryDocumentController.m
@@ -9,7 +9,6 @@
 #import "PBRepositoryDocumentController.h"
 #import "PBGitRepositoryDocument.h"
 #import "PBGitRevList.h"
-#import "PBEasyPipe.h"
 #import "PBGitBinary.h"
 
 #import <ObjectiveGit/GTRepository.h>

--- a/Classes/Controllers/PBServicesController.m
+++ b/Classes/Controllers/PBServicesController.m
@@ -9,6 +9,7 @@
 #import "PBServicesController.h"
 #import "PBGitRepositoryDocument.h"
 #import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
 
 @implementation PBServicesController
 

--- a/Classes/Controllers/PBWebController.m
+++ b/Classes/Controllers/PBWebController.m
@@ -8,6 +8,7 @@
 
 #import "PBWebController.h"
 #import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
 #import "PBGitXProtocol.h"
 #import "PBGitDefaults.h"
 

--- a/Classes/PBChangedFile.m
+++ b/Classes/PBChangedFile.m
@@ -7,7 +7,6 @@
 //
 
 #import "PBChangedFile.h"
-#import "PBEasyPipe.h"
 
 @implementation PBChangedFile
 

--- a/Classes/Util/NSApplication+GitXScripting.m
+++ b/Classes/Util/NSApplication+GitXScripting.m
@@ -12,7 +12,7 @@
 #import "PBGitRepository.h"
 #import "PBCloneRepositoryPanel.h"
 #import "PBGitBinary.h"
-#import "PBEasyPipe.h"
+#import "PBTask.h"
 
 
 @implementation NSApplication (GitXScripting)
@@ -31,23 +31,18 @@
     NSURL *repositoryURL = command.directParameter;
     NSArray *diffOptions = command.arguments[@"diffOptions"];
 
-	diffOptions = [[NSArray arrayWithObjects:@"diff", @"--no-ext-diff", nil] arrayByAddingObjectsFromArray:diffOptions];
+	diffOptions = [@[@"diff", @"--no-ext-diff"] arrayByAddingObjectsFromArray:diffOptions];
 
-	int retValue = 1;
-	NSString *diffOutput = [PBEasyPipe outputForCommand:[PBGitBinary path] withArgs:diffOptions inDir:[repositoryURL path] retValue:&retValue];
-	if (retValue) {
+	NSError *error = nil;
+	NSString *diffOutput = [PBTask outputForCommand:[PBGitBinary path] arguments:diffOptions inDirectory:repositoryURL.path error:&error];
+	if (!diffOutput) {
 		// if there is an error diffOutput should have the error output from git
-		if (diffOutput)
-			NSLog(@"%s\n", [diffOutput UTF8String]);
-		else
-			NSLog(@"Invalid diff command [%d]\n", retValue);
+		NSLog(@"Invalid diff command: %@", error);
         return;
 	}
 
-    if (diffOutput) {
-        PBDiffWindowController *diffController = [[PBDiffWindowController alloc] initWithDiff:diffOutput];
-        [diffController showWindow:self];
-    }
+	PBDiffWindowController *diffController = [[PBDiffWindowController alloc] initWithDiff:diffOutput];
+	[diffController showWindow:self];
 }
 
 - (void)initRepositoryScriptCommand:(NSScriptCommand *)command

--- a/Classes/Util/PBEasyPipe.h
+++ b/Classes/Util/PBEasyPipe.h
@@ -10,56 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const PBEasyPipeErrorDomain;
-extern NSString *const PBEasyPipeUnderlyingExceptionKey;
-extern NSString *const PBEasyPipeTerminationStatusKey;
-extern NSString *const PBEasyPipeTerminationOutputKey;
-
-typedef NS_ENUM(NSUInteger, PBEasyPipeError) {
-	PBEasyPipeTaskLaunchError = 1,
-	PBEasyPipeTaskTimeoutError = 2,
-	PBEasyPipeTaskCaughtSignalError = 3,
-	PBEasyPipeTaskNonZeroExitCodeError = 4,
-};
-
-
-
 @interface PBEasyPipe: NSObject
-
-///
-/// Execute a command in the shell.
-///
-/// This is a wrapper around NSTask that uses blocks to report when the
-/// executable exits, and should be used whenever we need to shell out to git.
-///
-/// @param command   The absolute path to the executable that should be run.
-/// @param arguments The arguments to pass to the executable.
-/// @param directory The directory to use as the executable working directory.
-/// @param terminationHandler A block that will be called when the executable exits.
-///
-+ (nullable NSTask *)performCommand:(NSString *)command arguments:(nullable NSArray *)arguments inDirectory:(nullable NSString *)directory terminationHandler:(void (^)(NSTask *task, NSError * __nullable error))terminationHandler;
-
-///
-/// Execute a command in the shell, and process its output.
-///
-/// @see -performCommand:arguments:inDirectory:terminationHandler:
-///
-/// @param command   The absolute path to the executable that should be run.
-/// @param arguments The arguments to pass to the executable.
-/// @param directory The directory to use as the executable working directory.
-/// @param completionHandler A block that will be called when the executable exits.
-///							 If readData is nil, it means an error occurred.
-///
-+ (nullable NSTask *)performCommand:(NSString *)command arguments:(nullable NSArray *)arguments inDirectory:(nullable NSString *)directory completionHandler:(void (^)(NSTask *task, NSData * __nullable readData, NSError * __nullable error))completionHandler;
-
-///
-/// Setup a task for subsequent execution.
-///
-/// @param command The absolute path to the executable that should be run.
-/// @param arguments The arguments to pass to the executable. Can be nil.
-/// @param directory The directory to use as the executable working directory. Can be nil.
-///
-+ (NSTask *)taskForCommand:(NSString *)command arguments:(nullable NSArray *)arguments inDirectory:(nullable NSString *)directory;
 
 /* The following methods are kept for backward-compatibility.
  * Newly-written code should use the block-based methods above.

--- a/Classes/Util/PBEasyPipe.m
+++ b/Classes/Util/PBEasyPipe.m
@@ -7,98 +7,10 @@
 //
 
 #import "PBEasyPipe.h"
-#import <objc/runtime.h>
-
-NSString *const PBEasyPipeErrorDomain = @"PBEasyPipeErrorDomain";
-NSString *const PBEasyPipeUnderlyingExceptionKey = @"PBEasyPipeUnderlyingExceptionKey";
-
-#pragma mark - NSPipe category
-
-/* Some NSTask's generate a lot of output. Using a regular pipe with these tasks causes the pipe to fill up before the
- task completes; it will basically fail silently. To fix this, the pipe must occasionally be read into a
- cache, but because this can occur at the end of a chain of async operations, it gets complicated. Instead, you can set
- the .dataOutput property on this NSPipe category, and the intermittent results automatically will be read into
- that NSMutableData.
- */
-
-@interface NSPipe (PBEasyPipe)
-
-@property (nonatomic, strong) NSMutableData *dataOutput;
-
-@end
-
-@implementation NSPipe (PBEasyPipe)
-
-- (void)setDataOutput:(nonnull NSMutableData *)dataOutput {
-	objc_setAssociatedObject(self, @selector(dataOutput), dataOutput, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-
-	NSFileHandle *fileHandle = self.fileHandleForReading;
-	NSAssert(fileHandle != nil, @"should have file handle for reading");
-
-	fileHandle.readabilityHandler = ^(NSFileHandle * _Nonnull fileHandle) {
-		[dataOutput appendData:fileHandle.availableData];
-		[fileHandle closeFile];
-	};
-}
-
-- (NSMutableData *)dataOutput {
-	return objc_getAssociatedObject(self, @selector(dataOutput));
-}
-
-- (void)clear {
-	self.fileHandleForReading.readabilityHandler = nil;
-}
-
-@end
 
 #pragma mark - PBEasyPipe implementation
 
 @implementation PBEasyPipe
-
-+ (nullable NSTask *)performCommand:(NSString *)command arguments:(NSArray *)arguments inDirectory:(NSString *)directory terminationHandler:(void (^)(NSTask *, NSError *error))terminationHandler {
-	NSParameterAssert(command != nil);
-
-	NSTask *task = [self taskForCommand:command arguments:arguments inDirectory:directory];
-	NSPipe *pipe = task.standardOutput;
-	pipe.dataOutput = [NSMutableData data];
-
-	task.terminationHandler = ^(NSTask *task) {
-		dispatch_async(dispatch_get_main_queue(), ^{
-			terminationHandler(task, nil);
-		});
-	};
-
-	@try {
-		[task launch];
-	} @catch (NSException *exception) {
-		NSString *desc = @"Exception raised while launching task";
-		NSString *failureReason = [NSString stringWithFormat:@"The task \"%@\" failed to launch", command];
-		NSDictionary *info = @{NSLocalizedDescriptionKey: desc,
-													 NSLocalizedFailureReasonErrorKey: failureReason,
-													 PBEasyPipeUnderlyingExceptionKey: exception};
-		NSError *error = [NSError errorWithDomain:PBEasyPipeErrorDomain code:PBEasyPipeTaskLaunchError userInfo:info];
-		terminationHandler(task, error);
-	}
-
-	return task;
-}
-
-+ (nullable NSTask *)performCommand:(NSString *)command arguments:(NSArray *)arguments inDirectory:(NSString *)directory completionHandler:(void (^)(NSTask *, NSData *readData, NSError *error))completionHandler {
-
-	return [self performCommand:command arguments:arguments inDirectory:directory terminationHandler:^(NSTask *task, NSError *error) {
-		NSPipe *pipe = task.standardOutput;
-
-		if (error) {
-			[pipe clear];
-			completionHandler(task, nil, error);
-			return;
-		}
-
-		[pipe clear];
-
-		completionHandler(task, pipe.dataOutput, nil);
-	}];
-}
 
 + (NSTask *)taskForCommand:(NSString *)cmd arguments:(NSArray *)args inDirectory:(NSString *)directory
 {

--- a/Classes/Util/PBTask.h
+++ b/Classes/Util/PBTask.h
@@ -36,25 +36,21 @@ typedef NS_ENUM(NSUInteger, PBTaskErrorCode) {
 + (instancetype)taskWithLaunchPath:(NSString *)launchPath arguments:(nullable NSArray *)arguments inDirectory:(nullable NSString *)directory;
 
 ///
-/// Execute a task
+/// Execute a task.
 ///
-/// @warning As per -[NSTask terminationHandler], there is no guarantee on which queue
-/// the block will be executed.
-///
+/// @param queue			  The queue on which the handler will be called.
 /// @param terminationHandler A block that will be called when the executable exits.
 ///
-- (void)performTaskWithTerminationHandler:(void (^)(NSError * __nullable error))terminationHandler;
+- (void)performTaskOnQueue:(dispatch_queue_t)queue terminationHandler:(void (^)(NSError * __nullable error))terminationHandler;
 
 ///
 /// Execute a task, and process its output
 ///
-/// @warning As per -[NSTask terminationHandler], there is no guarantee on which queue
-/// the block will be executed.
-///
+/// @param queue			 The queue on which the handler will be called.
 /// @param completionHandler A block that will be called when the executable exits.
 ///							 If readData is nil, it means an error occurred.
 ///
-- (void)performTaskWithCompletionHandler:(void (^)(NSData * __nullable readData, NSError * __nullable error))completionHandler;
+- (void)performTaskOnQueue:(dispatch_queue_t)queue completionHandler:(void (^)(NSData * __nullable readData, NSError * __nullable error))completionHandler;
 
 /// Execute a task synchronously
 ///
@@ -73,6 +69,24 @@ typedef NS_ENUM(NSUInteger, PBTaskErrorCode) {
 @property (retain) NSDictionary *additionalEnvironment;
 
 - (void)terminate;
+
+@end
+
+@interface PBTask (PBMainQueuePerform)
+
+/// Execute a task
+///
+/// This uses the main queue
+///
+/// @see performTaskOnQueue:terminationHandler:
+- (void)performTaskWithTerminationHandler:(void (^)(NSError * __nullable error))terminationHandler;
+
+/// Execute a task
+///
+/// This uses the main queue
+///
+/// @see performTaskOnQueue:completionHandler:
+- (void)performTaskWithCompletionHandler:(void (^)(NSData * __nullable readData, NSError * __nullable error))completionHandler;
 
 @end
 
@@ -111,7 +125,6 @@ typedef NS_ENUM(NSUInteger, PBTaskErrorCode) {
 /// If the data is not valid UTF-8, nil will be returned.
 ///
 - (nullable NSString *)standardOutputString;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Classes/Util/PBTask.h
+++ b/Classes/Util/PBTask.h
@@ -70,6 +70,7 @@ typedef NS_ENUM(NSUInteger, PBTaskErrorCode) {
 @property (readonly, retain) NSData *standardOutputData;
 /// Set this if you want to pass data to the command on its standard input
 @property (retain) NSData *standardInputData;
+@property (retain) NSDictionary *additionalEnvironment;
 
 - (void)terminate;
 

--- a/Classes/Util/PBTask.h
+++ b/Classes/Util/PBTask.h
@@ -1,0 +1,102 @@
+//
+//  PBTask.h
+//  GitX
+//
+//  Created by Etienne on 22/02/2017.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const PBTaskErrorDomain;
+extern NSString *const PBTaskUnderlyingExceptionKey;
+extern NSString *const PBTaskTerminationStatusKey;
+extern NSString *const PBTaskTerminationOutputKey;
+
+typedef NS_ENUM(NSUInteger, PBTaskErrorCode) {
+	PBTaskLaunchError = 1,
+	PBTaskTimeoutError = 2,
+	PBTaskCaughtSignalError = 3,
+	PBTaskNonZeroExitCodeError = 4,
+};
+
+/// PBTask is a wrapper around NSTask that uses blocks to report when the
+/// executable exits, and should be used whenever we need to shell out to git.
+@interface PBTask : NSObject
+
+///
+/// Setup a task for subsequent execution.
+///
+/// @param launchPath The absolute path to the executable that should be run.
+/// @param arguments  The arguments to pass to the executable. Can be nil.
+/// @param directory  The directory to use as the executable working directory. Can be nil.
+///
++ (instancetype)taskWithLaunchPath:(NSString *)launchPath arguments:(nullable NSArray *)arguments inDirectory:(nullable NSString *)directory;
+
+///
+/// Execute a task
+///
+/// @warning As per -[NSTask terminationHandler], there is no guarantee on which queue
+/// the block will be executed.
+///
+/// @param terminationHandler A block that will be called when the executable exits.
+///
+- (void)performTaskWithTerminationHandler:(void (^)(NSError * __nullable error))terminationHandler;
+
+///
+/// Execute a task, and process its output
+///
+/// @warning As per -[NSTask terminationHandler], there is no guarantee on which queue
+/// the block will be executed.
+///
+/// @param completionHandler A block that will be called when the executable exits.
+///							 If readData is nil, it means an error occurred.
+///
+- (void)performTaskWithCompletionHandler:(void (^)(NSData * __nullable readData, NSError * __nullable error))completionHandler;
+
+/// Execute a task synchronously
+///
+/// This method will block until the task exits, or a timeout occurs (30s by default).
+/// @param error     If the command failed to complete, the pointer will be set to
+///                  an error object describing the reason
+///
+/// @return YES if the command execution was successful, no otherwise
+///
+- (BOOL)launchTask:(NSError **)error;
+
+/// The standard output of the command
+@property (readonly, retain) NSData *standardOutputData;
+/// Set this if you want to pass data to the command on its standard input
+@property (retain) NSData *standardInputData;
+
+- (void)terminate;
+
+@end
+
+@interface PBTask (PBBellsAndWhistles)
+
+/// Execute a command, only caring for its output
+///
+/// @param launchPath The absolute path to the executable that should be run.
+/// @param arguments  The arguments to pass to the executable. Can be nil.
+///
+/// @return The data outputted by the command as a string, nil in case of failure.
+/// Hint: We only try to convert from UTF-8 data, so that might fail.
+///
++ (nullable NSString *)outputForCommand:(NSString *)launchPath arguments:(nullable NSArray *)arguments;
+
+/// Directly launch a task with a completion handler
+///
+/// @param launchPath The absolute path to the executable that should be run.
+/// @param arguments  The arguments to pass to the executable. Can be nil.
+/// @param directory  The directory to use as the executable working directory. Can be nil.
+/// @param completionHandler A block that will be called when the executable exits.
+///							 If readData is nil, it means an error occurred.
+///
++ (void)launchTask:(NSString *)launchPath arguments:(nullable NSArray *)arguments inDirectory:(nullable NSString *)directory completionHandler:(void (^)(NSData * __nullable readData, NSError * __nullable error))completionHandler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Util/PBTask.h
+++ b/Classes/Util/PBTask.h
@@ -80,13 +80,21 @@ typedef NS_ENUM(NSUInteger, PBTaskErrorCode) {
 
 /// Execute a command, only caring for its output
 ///
+/// @see -[PBTask outputForCommand:arguments:inDirectory:error]
+///
++ (nullable NSString *)outputForCommand:(NSString *)launchPath arguments:(nullable NSArray *)arguments error:(NSError **)error;
+
+
+/// Execute a command, only caring for its output
+///
 /// @param launchPath The absolute path to the executable that should be run.
 /// @param arguments  The arguments to pass to the executable. Can be nil.
+/// @param directory  The directory to use as the executable working directory. Can be nil.
 ///
 /// @return The data outputted by the command as a string, nil in case of failure.
 /// Hint: We only try to convert from UTF-8 data, so that might fail.
 ///
-+ (nullable NSString *)outputForCommand:(NSString *)launchPath arguments:(nullable NSArray *)arguments;
++ (nullable NSString *)outputForCommand:(NSString *)launchPath arguments:(nullable NSArray *)arguments inDirectory:(nullable NSString *)directory error:(NSError **)error;
 
 /// Directly launch a task with a completion handler
 ///

--- a/Classes/Util/PBTask.h
+++ b/Classes/Util/PBTask.h
@@ -106,6 +106,12 @@ typedef NS_ENUM(NSUInteger, PBTaskErrorCode) {
 ///
 + (void)launchTask:(NSString *)launchPath arguments:(nullable NSArray *)arguments inDirectory:(nullable NSString *)directory completionHandler:(void (^)(NSData * __nullable readData, NSError * __nullable error))completionHandler;
 
+/// Return the standard output data as a string
+///
+/// If the data is not valid UTF-8, nil will be returned.
+///
+- (nullable NSString *)standardOutputString;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -186,7 +186,7 @@ NSString *const PBTaskTerminationOutputKey = @"PBTaskTerminationOutputKey";
 	BOOL success = [task launchTask:error];
 	if (!success) return nil;
 
-	return [[NSString alloc] initWithData:task.standardOutputData encoding:NSUTF8StringEncoding];
+	return task.standardOutputString;
 }
 
 + (void)launchTask:(NSString *)launchPath arguments:(NSArray *)arguments inDirectory:(NSString *)directory completionHandler:(void (^)(NSData *readData, NSError *error))completionHandler {
@@ -194,5 +194,8 @@ NSString *const PBTaskTerminationOutputKey = @"PBTaskTerminationOutputKey";
 	[task performTaskWithCompletionHandler:completionHandler];
 }
 
+- (NSString *)standardOutputString {
+	return [[NSString alloc] initWithData:self.standardOutputData encoding:NSUTF8StringEncoding];
+}
 
 @end

--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -185,6 +185,14 @@ NSString *const PBTaskTerminationOutputKey = @"PBTaskTerminationOutputKey";
 	[self.task terminate];
 }
 
+- (NSString *)description {
+	NSArray *taskArguments = [@[self.task.launchPath] arrayByAddingObjectsFromArray:self.task.arguments];
+	return [NSString stringWithFormat:@"<%@ %p command: %@ stdin: %@>", NSStringFromClass([self class]), self,
+			[taskArguments componentsJoinedByString:@" "],
+			(self.standardInputData ? @"YES" : @"NO")
+			];
+}
+
 @end
 
 @implementation PBTask (PBBellsAndWhistles)

--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -1,0 +1,191 @@
+//
+//  PBTask.m
+//  GitX
+//
+//  Created by Etienne on 22/02/2017.
+//
+//
+
+#import "PBTask.h"
+
+NSString *const PBTaskErrorDomain = @"PBTaskErrorDomain";
+NSString *const PBTaskUnderlyingExceptionKey = @"PBTaskUnderlyingExceptionKey";
+NSString *const PBTaskTerminationStatusKey = @"PBTaskTerminationStatusKey";
+NSString *const PBTaskTerminationOutputKey = @"PBTaskTerminationOutputKey";
+
+@interface PBTask ()
+
+@property (retain) NSTask *task;
+
+@end
+
+@implementation PBTask
+
++ (instancetype)taskWithLaunchPath:(NSString *)launchPath arguments:(NSArray *)arguments inDirectory:(NSString *)directory {
+	return [[self alloc] initWithLaunchPath:launchPath arguments:arguments inDirectory:directory];
+}
+
+- (instancetype)initWithLaunchPath:(NSString *)launchPath arguments:(NSArray *)args inDirectory:(NSString *)directory
+{
+	self = [super init];
+	if (!self) return nil;
+
+	_task = [[NSTask alloc] init];
+	[_task setLaunchPath:launchPath];
+	[_task setArguments:args];
+
+	// Prepare ourselves a nicer environment
+	NSMutableDictionary *env = [[[NSProcessInfo processInfo] environment] mutableCopy];
+	[env removeObjectsForKeys:@[@"MallocStackLogging", @"MallocStackLoggingNoCompact", @"NSZombieEnabled"]];
+	[_task setEnvironment:env];
+
+	if (directory)
+		[_task setCurrentDirectoryPath:directory];
+
+	if ([[NSUserDefaults standardUserDefaults] boolForKey:@"Show Debug Messages"])
+		NSLog(@"Starting command `%@ %@` in dir %@", launchPath, [args componentsJoinedByString:@" "], directory);
+#ifdef CLI
+	NSLog(@"Starting command `%@ %@` in dir %@", launchPath, [args componentsJoinedByString:@" "], directory);
+#endif
+
+	NSPipe *pipe = [NSPipe pipe];
+	[_task setStandardOutput:pipe];
+	[_task setStandardError:pipe];
+
+	return self;
+}
+
+
+- (void)performTaskWithTerminationHandler:(void (^)(NSError *error))terminationHandler {
+	NSParameterAssert(terminationHandler != nil);
+
+	self.task.terminationHandler = ^(NSTask *task) {
+		NSError *error = nil;
+		if (task.terminationReason == NSTaskTerminationReasonUncaughtSignal) {
+
+			NSString *desc = @"Task killed";
+			NSArray *taskArguments = [@[task.launchPath] arrayByAddingObjectsFromArray:task.arguments];
+			NSString *failureReason = [NSString stringWithFormat:@"The task \"%@\" caught a termination signal", taskArguments];
+			NSDictionary *userInfo = @{
+									   NSLocalizedDescriptionKey: desc,
+									   NSLocalizedFailureReasonErrorKey: failureReason,
+									   };
+			error = [NSError errorWithDomain:PBTaskErrorDomain code:PBTaskCaughtSignalError userInfo:userInfo];
+
+		} else if (task.terminationReason == NSTaskTerminationReasonExit && task.terminationStatus != 0) {
+
+			NSString *desc = @"Task exited unsuccessfully";
+			NSArray *taskArguments = [@[task.launchPath] arrayByAddingObjectsFromArray:task.arguments];
+			NSString *failureReason = [NSString stringWithFormat:@"The task \"%@\" returned a non-zero return code", taskArguments];
+			NSDictionary *userInfo = @{
+									   NSLocalizedDescriptionKey: desc,
+									   NSLocalizedFailureReasonErrorKey: failureReason,
+									   PBTaskTerminationStatusKey: @(task.terminationStatus),
+									   };
+			error = [NSError errorWithDomain:PBTaskErrorDomain code:PBTaskNonZeroExitCodeError userInfo:userInfo];
+
+		}
+
+		terminationHandler(error);
+	};
+
+	if (self.standardInputData) {
+		NSPipe *inputPipe = [NSPipe pipe];
+
+		self.task.standardInput = inputPipe;
+
+		inputPipe.fileHandleForWriting.writeabilityHandler = ^(NSFileHandle *handle) {
+			[handle writeData:self.standardInputData];
+			[handle closeFile];
+		};
+	}
+
+	@try {
+		[self.task launch];
+	}
+	@catch (NSException *exception) {
+		NSString *desc = @"Exception raised while launching task";
+		NSString *failureReason = [NSString stringWithFormat:@"The task \"%@\" failed to launch", self.task.launchPath];
+		NSDictionary *info = @{
+							   NSLocalizedDescriptionKey: desc,
+							   NSLocalizedFailureReasonErrorKey: failureReason,
+							   PBTaskUnderlyingExceptionKey: exception,
+							   };
+		NSError *error = [NSError errorWithDomain:PBTaskErrorDomain
+											 code:PBTaskLaunchError
+										 userInfo:info];
+		terminationHandler(error);
+	}
+}
+
+- (void)performTaskWithCompletionHandler:(void (^)(NSData *readData, NSError *error))completionHandler {
+	return [self performTaskWithTerminationHandler:^(NSError *error) {
+		if (error) {
+			completionHandler(nil, error);
+			return;
+		}
+
+		NSData *data = [[self.task.standardOutput fileHandleForReading] readDataToEndOfFile];
+		completionHandler(data, nil);
+	}];
+}
+
+- (BOOL)launchTask:(NSError **)error {
+	dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+
+	__block NSError *taskError = nil;
+	[self performTaskWithCompletionHandler:^(NSData *readData, NSError *error) {
+
+		_standardOutputData = readData;
+		taskError = error;
+
+		dispatch_semaphore_signal(sem);
+	}];
+
+	dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC);
+	if (dispatch_semaphore_wait(sem, timeout) != 0) {
+		// Timeout !
+		// Unset the termination handler before calling, so we don't trigger it
+		self.task.terminationHandler = nil;
+		[self terminate];
+
+		if (error) {
+			NSString *desc = @"Timeout while running task";
+			NSArray *taskArguments = [@[self.task.launchPath] arrayByAddingObjectsFromArray:self.task.arguments];
+			NSString *failureReason = [NSString stringWithFormat:@"The task \"%@\" failed to complete before its timeout", taskArguments];
+			NSDictionary *userInfo = @{
+									   NSLocalizedDescriptionKey: desc,
+									   NSLocalizedFailureReasonErrorKey: failureReason,
+									   };
+			*error = [NSError errorWithDomain:PBTaskErrorDomain code:PBTaskTimeoutError userInfo:userInfo];
+		}
+
+		return NO;
+	}
+
+	return YES;
+}
+
+- (void)terminate {
+	[self.task terminate];
+}
+
+@end
+
+@implementation PBTask (PBBellsAndWhistles)
+
++ (NSString *)outputForCommand:(NSString *)launchPath arguments:(NSArray *)arguments {
+	PBTask *task = [self taskWithLaunchPath:launchPath arguments:arguments inDirectory:nil];
+	BOOL success = [task launchTask:NULL];
+	if (!success) return nil;
+
+	return [[NSString alloc] initWithData:task.standardOutputData encoding:NSUTF8StringEncoding];
+}
+
++ (void)launchTask:(NSString *)launchPath arguments:(NSArray *)arguments inDirectory:(NSString *)directory completionHandler:(void (^)(NSData *readData, NSError *error))completionHandler {
+	PBTask *task = [self taskWithLaunchPath:launchPath arguments:arguments inDirectory:directory];
+	[task performTaskWithCompletionHandler:completionHandler];
+}
+
+
+@end

--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -68,7 +68,7 @@ NSString *const PBTaskTerminationOutputKey = @"PBTaskTerminationOutputKey";
 
 			NSString *desc = @"Task killed";
 			NSArray *taskArguments = [@[task.launchPath] arrayByAddingObjectsFromArray:task.arguments];
-			NSString *failureReason = [NSString stringWithFormat:@"The task \"%@\" caught a termination signal", taskArguments];
+			NSString *failureReason = [NSString stringWithFormat:@"The task \"%@\" caught a termination signal", [taskArguments componentsJoinedByString:@" "]];
 			NSDictionary *userInfo = @{
 									   NSLocalizedDescriptionKey: desc,
 									   NSLocalizedFailureReasonErrorKey: failureReason,
@@ -83,7 +83,7 @@ NSString *const PBTaskTerminationOutputKey = @"PBTaskTerminationOutputKey";
 
 			NSString *desc = @"Task exited unsuccessfully";
 			NSArray *taskArguments = [@[task.launchPath] arrayByAddingObjectsFromArray:task.arguments];
-			NSString *failureReason = [NSString stringWithFormat:@"The task \"%@\" returned a non-zero return code", taskArguments];
+			NSString *failureReason = [NSString stringWithFormat:@"The task \"%@\" returned a non-zero return code", [taskArguments componentsJoinedByString:@" "]];
 			NSDictionary *userInfo = @{
 									   NSLocalizedDescriptionKey: desc,
 									   NSLocalizedFailureReasonErrorKey: failureReason,

--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -116,7 +116,6 @@ do { \
 
 			PBTaskLog(@"task %p: exit != 0", weakSelf);
 
-			[(NSMutableData *)weakSelf.standardOutputData appendData:[[task.standardOutput fileHandleForReading] readDataToEndOfFile]];
 			NSString *outputString = [[NSString alloc] initWithData:weakSelf.standardOutputData encoding:NSUTF8StringEncoding];
 			weakSelf.standardOutputData = nil;
 
@@ -189,7 +188,6 @@ do { \
 		@synchronized (self) {
 			PBTaskLog(@"task %p: completed, removing read handler", self);
 			[self.task.standardOutput fileHandleForReading].readabilityHandler = nil;
-			[(NSMutableData *)self.standardOutputData appendData:[[self.task.standardOutput fileHandleForReading] readDataToEndOfFile]];
 		}
 
 		completionHandler(self.standardOutputData, nil);

--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -36,7 +36,11 @@ NSString *const PBTaskTerminationOutputKey = @"PBTaskTerminationOutputKey";
 
 	// Prepare ourselves a nicer environment
 	NSMutableDictionary *env = [[[NSProcessInfo processInfo] environment] mutableCopy];
-	[env removeObjectsForKeys:@[@"MallocStackLogging", @"MallocStackLoggingNoCompact", @"NSZombieEnabled"]];
+	[env removeObjectsForKeys:@[
+								@"DYLD_INSERT_LIBRARIES", @"DYLD_LIBRARY_PATH",
+								@"MallocGuardEdges", @"MallocNanoZone", @"MallocScribble", @"MallocStackLogging", @"MallocStackLoggingNoCompact",
+								@"NSZombieEnabled"]
+	 ];
 	if (self.additionalEnvironment) {
 		[env addEntriesFromDictionary:self.additionalEnvironment];
 	}

--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -178,7 +178,8 @@ NSString *const PBTaskTerminationOutputKey = @"PBTaskTerminationOutputKey";
 		return NO;
 	}
 
-	return YES;
+	if (error) *error = taskError;
+	return (taskError == nil);
 }
 
 - (void)terminate {

--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -177,9 +177,13 @@ NSString *const PBTaskTerminationOutputKey = @"PBTaskTerminationOutputKey";
 
 @implementation PBTask (PBBellsAndWhistles)
 
-+ (NSString *)outputForCommand:(NSString *)launchPath arguments:(NSArray *)arguments {
-	PBTask *task = [self taskWithLaunchPath:launchPath arguments:arguments inDirectory:nil];
-	BOOL success = [task launchTask:NULL];
++ (NSString *)outputForCommand:(NSString *)launchPath arguments:(NSArray *)arguments error:(NSError **)error {
+	return [self outputForCommand:launchPath arguments:arguments inDirectory:nil error:error];
+}
+
++ (NSString *)outputForCommand:(NSString *)launchPath arguments:(NSArray *)arguments inDirectory:(NSString *)directory error:(NSError **)error {
+	PBTask *task = [self taskWithLaunchPath:launchPath arguments:arguments inDirectory:directory];
+	BOOL success = [task launchTask:error];
 	if (!success) return nil;
 
 	return [[NSString alloc] initWithData:task.standardOutputData encoding:NSUTF8StringEncoding];

--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -147,7 +147,12 @@ do { \
 		inputPipe.fileHandleForWriting.writeabilityHandler = ^(NSFileHandle *handle) {
 			PBTaskLog(@"task %p: can write %d", weakSelf, handle.fileDescriptor);
 
+			unsigned long long position = handle.offsetInFile;
+			PBTaskLog(@"task %p: at %lld", weakSelf, position);
 			[handle writeData:weakSelf.standardInputData];
+			if (handle.offsetInFile - position < weakSelf.standardInputData.length) {
+				// Did not write everything ?
+			}
 			[handle closeFile];
 		};
 	}

--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -37,6 +37,9 @@ NSString *const PBTaskTerminationOutputKey = @"PBTaskTerminationOutputKey";
 	// Prepare ourselves a nicer environment
 	NSMutableDictionary *env = [[[NSProcessInfo processInfo] environment] mutableCopy];
 	[env removeObjectsForKeys:@[@"MallocStackLogging", @"MallocStackLoggingNoCompact", @"NSZombieEnabled"]];
+	if (self.additionalEnvironment) {
+		[env addEntriesFromDictionary:self.additionalEnvironment];
+	}
 	[_task setEnvironment:env];
 
 	if (directory)

--- a/Classes/Util/PBTask.m
+++ b/Classes/Util/PBTask.m
@@ -72,7 +72,13 @@ do { \
 	pipe.fileHandleForReading.readabilityHandler = ^(NSFileHandle *handle) {
 		PBTaskLog(@"task %p: can read %d", weakSelf, handle.fileDescriptor);
 
-		[(NSMutableData *)weakSelf.standardOutputData appendData:handle.availableData];
+		NSData *data = handle.availableData;
+		if (data.length) {
+			[(NSMutableData *)weakSelf.standardOutputData appendData:data];
+		} else {
+			PBTaskLog(@"task %p: EOF, closing %d", weakSelf, handle.fileDescriptor);
+			[handle closeFile];
+		}
 	};
 
 	PBTaskLog(@"task %p: init", self);

--- a/Classes/git/PBGitBinary.h
+++ b/Classes/git/PBGitBinary.h
@@ -10,9 +10,7 @@
 
 #define MIN_GIT_VERSION "1.6.0"
 
-@interface PBGitBinary : NSObject {
-
-}
+@interface PBGitBinary : NSObject
 
 + (NSString *) path;
 + (NSString *) version;

--- a/Classes/git/PBGitBinary.m
+++ b/Classes/git/PBGitBinary.m
@@ -7,7 +7,7 @@
 //
 
 #import "PBGitBinary.h"
-#import "PBEasyPipe.h"
+#import "PBTask.h"
 
 @implementation PBGitBinary
 
@@ -21,7 +21,7 @@ static NSString* gitPath = nil;
 	if (![[NSFileManager defaultManager] fileExistsAtPath:path])
 		return nil;
 
-	NSString *version = [PBEasyPipe outputForCommand:path withArgs:[NSArray arrayWithObject:@"--version"]];
+	NSString *version = [PBTask outputForCommand:path arguments:@[@"--version"]];
 
 	return [self extractGitVersion:version];
 }
@@ -89,8 +89,7 @@ static NSString* gitPath = nil;
 	// No explicit path.
 	
 	// Try to find git with "which"
-	NSString* whichPath = [PBEasyPipe outputForCommand:@"/usr/bin/which"
-											  withArgs:[NSArray arrayWithObject:@"git"]];
+	NSString* whichPath = [PBTask outputForCommand:@"/usr/bin/which" arguments:@[@"git"]];
 	if ([self acceptBinary:whichPath])
 		return;
 
@@ -101,8 +100,7 @@ static NSString* gitPath = nil;
 	}
 	
 	// Lastly, try `xcrun git`
-	NSString* xcrunPath = [PBEasyPipe outputForCommand:@"/usr/bin/xcrun"
-											  withArgs:[NSArray arrayWithObjects:@"-f", @"git", nil]];
+	NSString* xcrunPath = [PBTask outputForCommand:@"/usr/bin/xcrun" arguments:@[@"-f", @"git"]];
 	if ([self acceptBinary:xcrunPath])
 	{
 		return;
@@ -153,6 +151,5 @@ static NSMutableArray *locations = nil;
 {
 	return [self versionForPath:gitPath];
 }
-
 
 @end

--- a/Classes/git/PBGitBinary.m
+++ b/Classes/git/PBGitBinary.m
@@ -21,7 +21,7 @@ static NSString* gitPath = nil;
 	if (![[NSFileManager defaultManager] fileExistsAtPath:path])
 		return nil;
 
-	NSString *version = [PBTask outputForCommand:path arguments:@[@"--version"]];
+	NSString *version = [PBTask outputForCommand:path arguments:@[@"--version"] error:NULL];
 
 	return [self extractGitVersion:version];
 }
@@ -89,7 +89,7 @@ static NSString* gitPath = nil;
 	// No explicit path.
 	
 	// Try to find git with "which"
-	NSString* whichPath = [PBTask outputForCommand:@"/usr/bin/which" arguments:@[@"git"]];
+	NSString* whichPath = [PBTask outputForCommand:@"/usr/bin/which" arguments:@[@"git"] error:NULL];
 	if ([self acceptBinary:whichPath])
 		return;
 
@@ -100,7 +100,7 @@ static NSString* gitPath = nil;
 	}
 	
 	// Lastly, try `xcrun git`
-	NSString* xcrunPath = [PBTask outputForCommand:@"/usr/bin/xcrun" arguments:@[@"-f", @"git"]];
+	NSString* xcrunPath = [PBTask outputForCommand:@"/usr/bin/xcrun" arguments:@[@"-f", @"git"] error:NULL];
 	if ([self acceptBinary:xcrunPath])
 	{
 		return;

--- a/Classes/git/PBGitCommit.m
+++ b/Classes/git/PBGitCommit.m
@@ -7,6 +7,7 @@
 //
 
 #import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
 #import "PBGitCommit.h"
 #import "PBGitTree.h"
 #import "PBGitRef.h"

--- a/Classes/git/PBGitIndex.m
+++ b/Classes/git/PBGitIndex.m
@@ -8,6 +8,7 @@
 
 #import "PBGitIndex.h"
 #import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
 #import "PBGitBinary.h"
 #import "PBTask.h"
 #import "PBChangedFile.h"

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -83,19 +83,6 @@ typedef enum branchFilterTypes {
 
 - (NSURL *) gitURL ;
 
-- (NSFileHandle*) handleForCommand:(NSString*) cmd GITX_DEPRECATED;
-- (NSFileHandle*) handleForArguments:(NSArray*) args GITX_DEPRECATED;
-- (NSFileHandle *) handleInWorkDirForArguments:(NSArray *)args GITX_DEPRECATED;
-- (NSString*) outputForCommand:(NSString*) cmd GITX_DEPRECATED;
-- (NSString *)outputForCommand:(NSString *)str retValue:(int *)ret GITX_DEPRECATED;
-- (NSString *)outputForArguments:(NSArray *)arguments inputString:(NSString *)input retValue:(int *)ret GITX_DEPRECATED;
-- (NSString *)outputForArguments:(NSArray *)arguments inputString:(NSString *)input byExtendingEnvironment:(NSDictionary *)dict retValue:(int *)ret GITX_DEPRECATED;
-
-
-- (NSString*) outputForArguments:(NSArray*) args GITX_DEPRECATED;
-- (NSString*) outputForArguments:(NSArray*) args retValue:(int *)ret GITX_DEPRECATED;
-- (NSString *)outputInWorkdirForArguments:(NSArray*) arguments GITX_DEPRECATED;
-- (NSString *)outputInWorkdirForArguments:(NSArray*) arguments retValue:(int *)ret GITX_DEPRECATED;
 - (BOOL)executeHook:(NSString *)name output:(NSString **)output GITX_DEPRECATED;
 - (BOOL)executeHook:(NSString *)name withArgs:(NSArray*) arguments output:(NSString **)output GITX_DEPRECATED;
 

--- a/Classes/git/PBGitRepository.h
+++ b/Classes/git/PBGitRepository.h
@@ -90,7 +90,7 @@ typedef enum branchFilterTypes {
 - (BOOL)executeHook:(NSString *)name arguments:(NSArray *)arguments error:(NSError **)error;
 - (BOOL)executeHook:(NSString *)name arguments:(NSArray *)arguments output:(NSString **)outputPtr error:(NSError **)error;
 
-- (NSString *)workingDirectory GITX_DEPRECATED;
+- (NSString *)workingDirectory;
 - (NSURL *)workingDirectoryURL;
 - (NSString *)projectName;
 

--- a/Classes/git/PBGitRepository.m
+++ b/Classes/git/PBGitRepository.m
@@ -7,6 +7,8 @@
 //
 
 #import "PBGitRepository.h"
+
+#import "PBGitRepository_PBGitBinarySupport.h"
 #import "PBGitCommit.h"
 #import "PBGitIndex.h"
 #import "PBGitWindowController.h"
@@ -1051,87 +1053,7 @@
 	return nil;
 }
 
-#pragma mark low level
-
-- (int) returnValueForCommand:(NSString *)cmd
-{
-	int i;
-	[self outputForCommand:cmd retValue: &i];
-	return i;
-}
-
-- (NSFileHandle*) handleForArguments:(NSArray *)args
-{
-	NSString* gitDirArg = [@"--git-dir=" stringByAppendingString:self.gitURL.path];
-	NSMutableArray* arguments =  [NSMutableArray arrayWithObject: gitDirArg];
-	[arguments addObjectsFromArray: args];
-	return [PBEasyPipe handleForCommand:[PBGitBinary path] withArgs:arguments];
-}
-
-- (NSFileHandle*) handleInWorkDirForArguments:(NSArray *)args
-{
-	NSString* gitDirArg = [@"--git-dir=" stringByAppendingString:self.gitURL.path];
-	NSMutableArray* arguments =  [NSMutableArray arrayWithObject: gitDirArg];
-	[arguments addObjectsFromArray: args];
-	return [PBEasyPipe handleForCommand:[PBGitBinary path] withArgs:arguments inDir:[self workingDirectory]];
-}
-
-- (NSFileHandle*) handleForCommand:(NSString *)cmd
-{
-	NSArray* arguments = [cmd componentsSeparatedByString:@" "];
-	return [self handleForArguments:arguments];
-}
-
-- (NSString*) outputForCommand:(NSString *)cmd
-{
-	NSArray* arguments = [cmd componentsSeparatedByString:@" "];
-	return [self outputForArguments: arguments];
-}
-
-- (NSString*) outputForCommand:(NSString *)str retValue:(int *)ret;
-{
-	NSArray* arguments = [str componentsSeparatedByString:@" "];
-	return [self outputForArguments: arguments retValue: ret];
-}
-
-- (NSString*) outputForArguments:(NSArray*) arguments
-{
-	return [PBEasyPipe outputForCommand:[PBGitBinary path] withArgs:arguments inDir: self.workingDirectory];
-}
-
-- (NSString*) outputInWorkdirForArguments:(NSArray*) arguments
-{
-	return [PBEasyPipe outputForCommand:[PBGitBinary path] withArgs:arguments inDir:self.workingDirectory];
-}
-
-- (NSString*) outputInWorkdirForArguments:(NSArray *)arguments retValue:(int *)ret
-{
-	return [PBEasyPipe outputForCommand:[PBGitBinary path] withArgs:arguments inDir:self.workingDirectory retValue: ret];
-}
-
-- (NSString*) outputForArguments:(NSArray *)arguments retValue:(int *)ret
-{
-	return [PBEasyPipe outputForCommand:[PBGitBinary path] withArgs:arguments inDir: self.workingDirectory retValue: ret];
-}
-
-- (NSString*) outputForArguments:(NSArray *)arguments inputString:(NSString *)input retValue:(int *)ret
-{
-	return [PBEasyPipe outputForCommand:[PBGitBinary path]
-							   withArgs:arguments
-								  inDir:self.workingDirectory
-							inputString:input
-							   retValue: ret];
-}
-
-- (NSString *)outputForArguments:(NSArray *)arguments inputString:(NSString *)input byExtendingEnvironment:(NSDictionary *)dict retValue:(int *)ret
-{
-	return [PBEasyPipe outputForCommand:[PBGitBinary path]
-							   withArgs:arguments
-								  inDir:self.workingDirectory
-				 byExtendingEnvironment:dict
-							inputString:input
-							   retValue: ret];
-}
+#pragma mark Hooks
 
 - (BOOL)executeHook:(NSString *)name output:(NSString **)output {
 	return [self executeHook:name withArgs:[NSArray array] output:output];

--- a/Classes/git/PBGitRepositoryWatcher.m
+++ b/Classes/git/PBGitRepositoryWatcher.m
@@ -9,7 +9,6 @@
 
 #import "PBGitRepositoryWatcher.h"
 #import "PBGitRepository.h"
-#import "PBEasyPipe.h"
 #import "PBGitDefaults.h"
 
 NSString *PBGitRepositoryEventNotification = @"PBGitRepositoryModifiedNotification";

--- a/Classes/git/PBGitRepository_PBGitBinarySupport.h
+++ b/Classes/git/PBGitRepository_PBGitBinarySupport.h
@@ -1,0 +1,38 @@
+//
+//  PBGitRepository_PBGitBinarySupport.h
+//  GitX
+//
+//  Created by Etienne on 22/02/2017.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "PBGitRepository.h"
+
+@class PBTask;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PBGitRepository (PBGitBinarySupport)
+- (PBTask *)taskWithArguments:(nullable NSArray *)arguments;
+- (BOOL)launchTaskWithArguments:(nullable NSArray *)arguments error:(NSError **)error;
+- (nullable NSString *)outputOfTaskWithArguments:(nullable NSArray *)arguments error:(NSError **)error;
+@end
+
+@interface PBGitRepository (PBGitBinarySupportDeprecated)
+- (NSFileHandle*) handleForCommand:(NSString*) cmd GITX_DEPRECATED;
+- (NSFileHandle*) handleForArguments:(NSArray*) args GITX_DEPRECATED;
+- (NSFileHandle *) handleInWorkDirForArguments:(NSArray *)args GITX_DEPRECATED;
+- (NSString*) outputForCommand:(NSString*) cmd GITX_DEPRECATED;
+- (NSString *)outputForCommand:(NSString *)str retValue:(int *)ret GITX_DEPRECATED;
+- (NSString *)outputForArguments:(NSArray *)arguments inputString:(NSString *)input retValue:(int *)ret GITX_DEPRECATED;
+- (NSString *)outputForArguments:(NSArray *)arguments inputString:(NSString *)input byExtendingEnvironment:(NSDictionary *)dict retValue:(int *)ret GITX_DEPRECATED;
+
+
+- (NSString*) outputForArguments:(NSArray*) args GITX_DEPRECATED;
+- (NSString*) outputForArguments:(NSArray*) args retValue:(int *)ret GITX_DEPRECATED;
+- (NSString *)outputInWorkdirForArguments:(NSArray*) arguments GITX_DEPRECATED;
+- (NSString *)outputInWorkdirForArguments:(NSArray*) arguments retValue:(int *)ret GITX_DEPRECATED;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/git/PBGitRepository_PBGitBinarySupport.h
+++ b/Classes/git/PBGitRepository_PBGitBinarySupport.h
@@ -8,8 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "PBGitRepository.h"
-
-@class PBTask;
+#import "PBTask.h" // Imported so our includers don't have to add it
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Classes/git/PBGitRepository_PBGitBinarySupport.m
+++ b/Classes/git/PBGitRepository_PBGitBinarySupport.m
@@ -1,0 +1,123 @@
+//
+//  PBGitRepository_PBGitBinarySupport.m
+//  GitX
+//
+//  Created by Etienne on 22/02/2017.
+//
+//
+
+#import "PBGitRepository_PBGitBinarySupport.h"
+
+#import "PBEasyPipe.h"
+#import "PBGitBinary.h"
+#import "PBTask.h"
+
+@implementation PBGitRepository (PBGitBinarySupport)
+
+- (PBTask *)taskWithArguments:(NSArray *)arguments
+{
+	NSArray *realArgs = @[[@"--git-dir=" stringByAppendingString:self.gitURL.path]];
+
+	// Prepend a --git-dir argument in case we're running against a bare repository
+	realArgs = [realArgs arrayByAddingObjectsFromArray:arguments];
+
+	return [PBTask taskWithLaunchPath:[PBGitBinary path] arguments:realArgs inDirectory:self.workingDirectory];
+}
+
+- (BOOL)launchTaskWithArguments:(nullable NSArray *)arguments error:(NSError **)error {
+	PBTask *task = [self taskWithArguments:arguments];
+	return [task launchTask:error];
+}
+
+- (NSString *)outputOfTaskWithArguments:(NSArray *)arguments error:(NSError **)error {
+	PBTask *task = [self taskWithArguments:arguments];
+	BOOL success = [task launchTask:error];
+	if (!success) return nil;
+
+	return [task standardOutputString];
+}
+
+@end
+
+@implementation PBGitRepository (PBGitBinarySupportDeprecated)
+
+- (int) returnValueForCommand:(NSString *)cmd
+{
+	int i;
+	[self outputForCommand:cmd retValue: &i];
+	return i;
+}
+
+- (NSFileHandle*) handleForArguments:(NSArray *)args
+{
+	NSString* gitDirArg = [@"--git-dir=" stringByAppendingString:self.gitURL.path];
+	NSMutableArray* arguments =  [NSMutableArray arrayWithObject: gitDirArg];
+	[arguments addObjectsFromArray: args];
+	return [PBEasyPipe handleForCommand:[PBGitBinary path] withArgs:arguments];
+}
+
+- (NSFileHandle*) handleInWorkDirForArguments:(NSArray *)args
+{
+	NSString* gitDirArg = [@"--git-dir=" stringByAppendingString:self.gitURL.path];
+	NSMutableArray* arguments =  [NSMutableArray arrayWithObject: gitDirArg];
+	[arguments addObjectsFromArray: args];
+	return [PBEasyPipe handleForCommand:[PBGitBinary path] withArgs:arguments inDir:[self workingDirectory]];
+}
+
+- (NSFileHandle*) handleForCommand:(NSString *)cmd
+{
+	NSArray* arguments = [cmd componentsSeparatedByString:@" "];
+	return [self handleForArguments:arguments];
+}
+
+- (NSString*) outputForCommand:(NSString *)cmd
+{
+	NSArray* arguments = [cmd componentsSeparatedByString:@" "];
+	return [self outputForArguments: arguments];
+}
+
+- (NSString*) outputForCommand:(NSString *)str retValue:(int *)ret;
+{
+	NSArray* arguments = [str componentsSeparatedByString:@" "];
+	return [self outputForArguments: arguments retValue: ret];
+}
+
+- (NSString*) outputForArguments:(NSArray*) arguments
+{
+	return [PBEasyPipe outputForCommand:[PBGitBinary path] withArgs:arguments inDir: self.workingDirectory];
+}
+
+- (NSString*) outputInWorkdirForArguments:(NSArray*) arguments
+{
+	return [PBEasyPipe outputForCommand:[PBGitBinary path] withArgs:arguments inDir:self.workingDirectory];
+}
+
+- (NSString*) outputInWorkdirForArguments:(NSArray *)arguments retValue:(int *)ret
+{
+	return [PBEasyPipe outputForCommand:[PBGitBinary path] withArgs:arguments inDir:self.workingDirectory retValue: ret];
+}
+
+- (NSString*) outputForArguments:(NSArray *)arguments retValue:(int *)ret
+{
+	return [PBEasyPipe outputForCommand:[PBGitBinary path] withArgs:arguments inDir: self.workingDirectory retValue: ret];
+}
+
+- (NSString*) outputForArguments:(NSArray *)arguments inputString:(NSString *)input retValue:(int *)ret
+{
+	return [PBEasyPipe outputForCommand:[PBGitBinary path]
+							   withArgs:arguments
+								  inDir:self.workingDirectory
+							inputString:input
+							   retValue: ret];
+}
+
+- (NSString *)outputForArguments:(NSArray *)arguments inputString:(NSString *)input byExtendingEnvironment:(NSDictionary *)dict retValue:(int *)ret
+{
+	return [PBEasyPipe outputForCommand:[PBGitBinary path]
+							   withArgs:arguments
+								  inDir:self.workingDirectory
+				 byExtendingEnvironment:dict
+							inputString:input
+							   retValue: ret];
+}
+@end

--- a/Classes/git/PBGitRevList.mm
+++ b/Classes/git/PBGitRevList.mm
@@ -11,7 +11,6 @@
 #import "PBGitCommit.h"
 #import "PBGitGrapher.h"
 #import "PBGitRevSpecifier.h"
-#import "PBEasyPipe.h"
 #import "PBGitBinary.h"
 
 #import <ObjectiveGit/ObjectiveGit.h>

--- a/Classes/git/PBGitTree.m
+++ b/Classes/git/PBGitTree.m
@@ -79,15 +79,8 @@
 {
 	@try {
 		// First ask git check-attr if the file has a binary attribute custom set
-		NSFileHandle *handle = [repository handleInWorkDirForArguments:
-								[NSArray arrayWithObjects:
-								 @"check-attr",
-								 @"binary",
-								 [self fullPath],
-								 nil]];
-
-		NSData *data = [handle readDataToEndOfFile];
-		NSString *string = [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding];
+		NSError *error = nil;
+		NSString *string = [repository outputOfTaskWithArguments:@[@"check-attr", @"binary", self.fullPath] error:&error];
 		
 		if (!string)
 			return NO;
@@ -124,8 +117,8 @@
 			string = [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding];
 		return string;
 	}
-	
-	return [repository outputForArguments:[NSArray arrayWithObjects:@"show", [self refSpec], nil]];
+
+	return [repository outputOfTaskWithArguments:@[@"show", self.refSpec] error:NULL];
 }
 
 - (NSString *) blame
@@ -138,8 +131,8 @@
 	
 	if ([self fileSize] > 52428800) // ~50MB
 		return [NSString stringWithFormat:@"%@ is too big to be displayed (%lld bytes)", [self fullPath], [self fileSize]];
-	
-	NSString *contents=[repository outputInWorkdirForArguments:[NSArray arrayWithObjects:@"blame", @"-p",  sha, @"--", [self fullPath], nil]];
+
+	NSString *contents = [repository outputOfTaskWithArguments:@[@"blame", @"-p", sha, @"--", self.fullPath] error:NULL];
 	
 	if ([self hasBinaryHeader:contents])
 		return [NSString stringWithFormat:@"%@ appears to be a binary file of %lld bytes", [self fullPath], [self fileSize]];
@@ -159,13 +152,14 @@
 	if ([self fileSize] > 52428800) // ~50MB
 		return [NSString stringWithFormat:@"%@ is too big to be displayed (%lld bytes)", [self fullPath], [self fileSize]];
 
-	NSString *contents = [repository outputInWorkdirForArguments:@[
-		@"log",
-		[NSString stringWithFormat:@"--pretty=format:%@",format],
-		@"--follow",
-		@"--",
-		[self fullPath],
-	]];
+	NSArray *arguments = @[
+						   @"log",
+						   [NSString stringWithFormat:@"--pretty=format:%@", format],
+						   @"--follow",
+						   @"--",
+						   [self fullPath],
+						   ];
+	NSString *contents = [repository outputOfTaskWithArguments:arguments error:NULL];
 
 	if ([self hasBinaryHeader:contents])
 		return [NSString stringWithFormat:@"%@ appears to be a binary file of %lld bytes", [self fullPath], [self fileSize]];
@@ -179,8 +173,7 @@
 	if (_fileSize)
 		return _fileSize;
 
-	NSFileHandle *handle = [repository handleForArguments:[NSArray arrayWithObjects:@"cat-file", @"-s", [self refSpec], nil]];
-	NSString *sizeString = [[NSString alloc] initWithData:[handle readDataToEndOfFile] encoding:NSISOLatin1StringEncoding];
+	NSString *sizeString = [repository outputOfTaskWithArguments:@[@"cat-file", @"-s", self.refSpec] error:NULL];
 
 	if (!sizeString)
 		_fileSize = -1;
@@ -214,9 +207,11 @@
 	NSString* newName = [dir stringByAppendingPathComponent:path];
 
 	if (leaf) {
-		NSFileHandle* handle = [repository handleForArguments:[NSArray arrayWithObjects:@"show", [self refSpec], nil]];
-		NSData* data = [handle readDataToEndOfFile];
-		[data writeToFile:newName atomically:YES];
+		PBTask *task = [repository taskWithArguments:@[@"show", self.refSpec]];
+
+		[task launchTask:NULL];
+
+		[task.standardOutputData writeToFile:newName atomically:YES];
 	} else { // Directory
         NSError *error = nil;
 		if (![[NSFileManager defaultManager] createDirectoryAtPath:newName withIntermediateDirectories:YES attributes:nil error:&error]) {
@@ -255,10 +250,13 @@
 	
 	if (!localFileName)
 		localFileName = [[PBEasyFS tmpDirWithPrefix: sha] stringByAppendingPathComponent:path];
-	
-	NSFileHandle* handle = [repository handleForArguments:[NSArray arrayWithObjects:@"show", [self refSpec], nil]];
-	NSData* data = [handle readDataToEndOfFile];
-	[data writeToFile:localFileName atomically:YES];
+
+
+	PBTask *task = [repository taskWithArguments:@[@"show", self.refSpec]];
+
+	[task launchTask:NULL];
+
+	[task.standardOutputData writeToFile:localFileName atomically:YES];
 	
 	NSFileManager* fs = [NSFileManager defaultManager];
 	localMtime = [[fs attributesOfItemAtPath:localFileName error: nil] objectForKey:NSFileModificationDate];

--- a/Classes/git/PBGitTree.m
+++ b/Classes/git/PBGitTree.m
@@ -11,7 +11,6 @@
 #import "PBGitTree.h"
 #import "PBGitCommit.h"
 #import "NSFileHandleExt.h"
-#import "PBEasyPipe.h"
 #import "PBEasyFS.h"
 
 @implementation PBGitTree

--- a/Classes/git/PBGitTree.m
+++ b/Classes/git/PBGitTree.m
@@ -7,6 +7,7 @@
 //
 
 #import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
 #import "PBGitTree.h"
 #import "PBGitCommit.h"
 #import "NSFileHandleExt.h"

--- a/Classes/git/PBGitXProtocol.h
+++ b/Classes/git/PBGitXProtocol.h
@@ -9,9 +9,7 @@
 #import <Cocoa/Cocoa.h>
 @class PBGitRepository;
 
-@interface PBGitXProtocol : NSURLProtocol {
-	NSFileHandle *handle;
-}
+@interface PBGitXProtocol : NSURLProtocol
 @end
 
 @interface NSURLRequest (PBGitXProtocol)

--- a/Classes/git/PBGitXProtocol.m
+++ b/Classes/git/PBGitXProtocol.m
@@ -10,6 +10,11 @@
 #import "PBGitRepository.h"
 #import "PBGitRepository_PBGitBinarySupport.h"
 
+@interface PBGitXProtocol () {
+	PBTask *_task;
+}
+@end
+
 @implementation PBGitXProtocol
 
 + (BOOL) canInitWithRequest:(NSURLRequest *)request
@@ -31,15 +36,22 @@
     NSURL *url = [[self request] URL];
 	PBGitRepository *repo = [[self request] repository];
 
-	if(!repo) {
+	if (!repo) {
 		[[self client] URLProtocol:self didFailWithError:[NSError errorWithDomain:NSURLErrorDomain code:0 userInfo:nil]];
 		return;
     }
 
 	NSString *specifier = [NSString stringWithFormat:@"%@:%@", [url host], [[url path] substringFromIndex:1]];
-	handle = [repo handleInWorkDirForArguments:[NSArray arrayWithObjects:@"cat-file", @"blob", specifier, nil]];
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didFinishFileLoad:) name:NSFileHandleReadToEndOfFileCompletionNotification object:handle];
-	[handle readToEndOfFileInBackgroundAndNotify];
+	_task = [repo taskWithArguments:@[@"cat-file", @"blob", specifier]];
+	[_task performTaskWithCompletionHandler:^(NSData *readData, NSError *error) {
+		if (error) {
+			[[self client] URLProtocol:self didFailWithError:error];
+			return;
+		}
+
+		[[self client] URLProtocol:self didLoadData:readData];
+		[[self client] URLProtocolDidFinishLoading:self];
+	}];
 
     NSURLResponse *response = [[NSURLResponse alloc] initWithURL:[[self request] URL]
 														MIMEType:nil
@@ -51,16 +63,9 @@
 			cacheStoragePolicy:NSURLCacheStorageNotAllowed];
 }
 
-- (void) didFinishFileLoad:(NSNotification *)notification
-{
-	NSData *data = [[notification userInfo] valueForKey:NSFileHandleNotificationDataItem];
-    [[self client] URLProtocol:self didLoadData:data];
-    [[self client] URLProtocolDidFinishLoading:self];
-}
-
 - (void) stopLoading
 {
-	[[NSNotificationCenter defaultCenter] removeObserver:self];
+	[_task terminate];
 }
 
 @end

--- a/Classes/git/PBGitXProtocol.m
+++ b/Classes/git/PBGitXProtocol.m
@@ -8,6 +8,7 @@
 
 #import "PBGitXProtocol.h"
 #import "PBGitRepository.h"
+#import "PBGitRepository_PBGitBinarySupport.h"
 
 @implementation PBGitXProtocol
 

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		4D6E4F7A1E56851A004C3A6F /* PBMacros.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D6E4F781E56851A004C3A6F /* PBMacros.m */; };
 		4DECFBB21E662962004C3A6F /* ObjectiveGit+PBCategories.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DECFBB11E662962004C3A6F /* ObjectiveGit+PBCategories.m */; };
 		4D843B1F1E5D27C3004C3A6F /* PBTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D843B1E1E5D27C3004C3A6F /* PBTask.m */; };
+		4D843B401E5E3939004C3A6F /* PBGitRepository_PBGitBinarySupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D843B3F1E5E3939004C3A6F /* PBGitRepository_PBGitBinarySupport.m */; };
 		551BF176112F3F4B00265053 /* gitx_askpasswd in Resources */ = {isa = PBXBuildFile; fileRef = 551BF111112F371800265053 /* gitx_askpasswd */; };
 		643952771603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 643952761603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m */; };
 		6C25810B1C2720E60080A89A /* GitXCommitCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C25810A1C2720E60080A89A /* GitXCommitCopier.m */; };
@@ -579,6 +580,8 @@
 		4DC1853818E6F93200E8DB8F /* Info-gitx.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-gitx.plist"; path = "../Resources/Info-gitx.plist"; sourceTree = "<group>"; };
 		4D843B1D1E5D27C3004C3A6F /* PBTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBTask.h; sourceTree = "<group>"; };
 		4D843B1E1E5D27C3004C3A6F /* PBTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBTask.m; sourceTree = "<group>"; };
+		4D843B3E1E5E3939004C3A6F /* PBGitRepository_PBGitBinarySupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBGitRepository_PBGitBinarySupport.h; sourceTree = "<group>"; };
+		4D843B3F1E5E3939004C3A6F /* PBGitRepository_PBGitBinarySupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBGitRepository_PBGitBinarySupport.m; sourceTree = "<group>"; };
 		4DE23D041CF31237004C3A6F /* src */ = {isa = PBXFileReference; lastKnownFileType = folder; name = src; path = "objective-git/External/libgit2/src"; sourceTree = "<group>"; };
 		4DE23D051CF31252004C3A6F /* include */ = {isa = PBXFileReference; lastKnownFileType = folder; name = include; path = "objective-git/External/libgit2/include"; sourceTree = "<group>"; };
 		4DECFBB01E662962004C3A6F /* ObjectiveGit+PBCategories.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ObjectiveGit+PBCategories.h"; sourceTree = "<group>"; };
@@ -986,6 +989,8 @@
 				4AB057E21652652000DE751D /* PBRepositoryFinder.m */,
 				2682AAB91929140E00271A4D /* GTOID+JavaScript.h */,
 				2682AABA1929140E00271A4D /* GTOID+JavaScript.m */,
+				4D843B3E1E5E3939004C3A6F /* PBGitRepository_PBGitBinarySupport.h */,
+				4D843B3F1E5E3939004C3A6F /* PBGitRepository_PBGitBinarySupport.m */,
 			);
 			path = git;
 			sourceTree = "<group>";
@@ -1512,6 +1517,7 @@
 				4A5D773014A9A9CC00DF6C68 /* PBGitRevisionCell.m in Sources */,
 				4A5D773114A9A9CC00DF6C68 /* PBGitXMessageSheet.m in Sources */,
 				4A5D773214A9A9CC00DF6C68 /* PBIconAndTextCell.m in Sources */,
+				4D843B401E5E3939004C3A6F /* PBGitRepository_PBGitBinarySupport.m in Sources */,
 				4A5D773414A9A9CC00DF6C68 /* PBQLOutlineView.m in Sources */,
 				4A5D773514A9A9CC00DF6C68 /* PBQLTextView.m in Sources */,
 				4A5D773614A9A9CC00DF6C68 /* PBRefMenuItem.m in Sources */,

--- a/GitX.xcodeproj/project.pbxproj
+++ b/GitX.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		4D3FB3E7198AEAAF000B4A58 /* PBGitRepositoryDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D3FB3E6198AEAAF000B4A58 /* PBGitRepositoryDocument.m */; };
 		4D6E4F7A1E56851A004C3A6F /* PBMacros.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D6E4F781E56851A004C3A6F /* PBMacros.m */; };
 		4DECFBB21E662962004C3A6F /* ObjectiveGit+PBCategories.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DECFBB11E662962004C3A6F /* ObjectiveGit+PBCategories.m */; };
+		4D843B1F1E5D27C3004C3A6F /* PBTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D843B1E1E5D27C3004C3A6F /* PBTask.m */; };
 		551BF176112F3F4B00265053 /* gitx_askpasswd in Resources */ = {isa = PBXBuildFile; fileRef = 551BF111112F371800265053 /* gitx_askpasswd */; };
 		643952771603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 643952761603EF9B00BB7AFF /* PBGitSVSubmoduleItem.m */; };
 		6C25810B1C2720E60080A89A /* GitXCommitCopier.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C25810A1C2720E60080A89A /* GitXCommitCopier.m */; };
@@ -576,6 +577,8 @@
 		4D6E4F781E56851A004C3A6F /* PBMacros.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBMacros.m; sourceTree = "<group>"; };
 		4D6E4F791E56851A004C3A6F /* PBMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBMacros.h; sourceTree = "<group>"; };
 		4DC1853818E6F93200E8DB8F /* Info-gitx.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-gitx.plist"; path = "../Resources/Info-gitx.plist"; sourceTree = "<group>"; };
+		4D843B1D1E5D27C3004C3A6F /* PBTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBTask.h; sourceTree = "<group>"; };
+		4D843B1E1E5D27C3004C3A6F /* PBTask.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBTask.m; sourceTree = "<group>"; };
 		4DE23D041CF31237004C3A6F /* src */ = {isa = PBXFileReference; lastKnownFileType = folder; name = src; path = "objective-git/External/libgit2/src"; sourceTree = "<group>"; };
 		4DE23D051CF31252004C3A6F /* include */ = {isa = PBXFileReference; lastKnownFileType = folder; name = include; path = "objective-git/External/libgit2/include"; sourceTree = "<group>"; };
 		4DECFBB01E662962004C3A6F /* ObjectiveGit+PBCategories.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ObjectiveGit+PBCategories.h"; sourceTree = "<group>"; };
@@ -1012,6 +1015,8 @@
 				6C25810A1C2720E60080A89A /* GitXCommitCopier.m */,
 				4DECFBB01E662962004C3A6F /* ObjectiveGit+PBCategories.h */,
 				4DECFBB11E662962004C3A6F /* ObjectiveGit+PBCategories.m */,
+				4D843B1D1E5D27C3004C3A6F /* PBTask.h */,
+				4D843B1E1E5D27C3004C3A6F /* PBTask.m */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -1461,6 +1466,7 @@
 				4A5D76FC14A9A9CC00DF6C68 /* PBGitIndex.m in Sources */,
 				4A5D76FD14A9A9CC00DF6C68 /* PBGitLane.mm in Sources */,
 				4A5D76FE14A9A9CC00DF6C68 /* PBGitRef.m in Sources */,
+				4D843B1F1E5D27C3004C3A6F /* PBTask.m in Sources */,
 				4A5D76FF14A9A9CC00DF6C68 /* PBGitRepository.m in Sources */,
 				4A5D770014A9A9CC00DF6C68 /* PBGitRepositoryWatcher.m in Sources */,
 				4A5D770214A9A9CC00DF6C68 /* PBGitRevList.mm in Sources */,


### PR DESCRIPTION
I gave this branch a try and switched PBRemoteProgressSheet to use PBTask while I was trying it out.

It also seems like the `readDataToEndOfFile` calls in PBTask are unnecessary since the readabilityHandler will read the data. They were throwing exceptions for me when a PBTask was run.